### PR TITLE
Add 'recreate' option that will always recreate the slug

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,8 @@ var defaultOptions = {
   index_trim: true,
   index_unique: true,
   index_required: false,
-  index_sparse: false
+  index_sparse: false,
+  recreate: false
 };
 
 module.exports = function(slugFields, options) {
@@ -178,9 +179,15 @@ module.exports = function(slugFields, options) {
     schema.pre('validate', function(next) {
       var doc = this;
       var currentSlug = doc.get(options.field, String);
-      if (!doc.isNew && !options.update && currentSlug) return next();
-
       var slugFieldsModified = doc.isNew;
+      if (doc.recreate) {
+        slugFieldsModified = true;
+      } else {
+        if (!doc.isNew && !options.update && currentSlug) {
+          return next();
+        }
+      }
+
       var toSlugify = '';
       if (slugFields instanceof Array) {
         for (var i = 0; i < slugFields.length; i++) {


### PR DESCRIPTION
Added the 'recreate' option (defaults to false). It will always re-create the slug, regardless if the slug fields have changed or not. I found it useful when wanting to existing documents that don't have the slug yet. 